### PR TITLE
Update supported node versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ['16', '18', '20']
+        node_version: ['18', '20', '21']
     steps:
       # Check out the project
       - uses: actions/checkout@v4


### PR DESCRIPTION
As of 2/20/24:
* 18 is in maintenance mode
* 20 is the current LTS
* 21 is the latest released version